### PR TITLE
Some minor tweaks to Git nomenclature for clarity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ tmp/**
 node_modules/
 .sass-cache
 .idea
+# editor temp files
+.*sw?
+*~

--- a/git.md
+++ b/git.md
@@ -109,16 +109,16 @@ Why would you use remote repos?
 * Automated Services
 
 Each repository can have multiple "remotes", you refer to them with aliases.  
-_(Github is just another remote repository.)_
+_(GitHub is just another remote repository.)_
 
 ---
 
-> **_In-Class Exercise (5-minutes)_:** Create a New Github Repo
+> **_In-Class Exercise (5-minutes)_:** Create a New GitHub Repo
 
-> 1. Login to Github.
+> 1. Login to GitHub.
 2. Create a new public repository.
 3. Follow on-screen instructions to add remote to your local repository.
-4. Push changes to Github.
+4. Push changes to GitHub.
 5. Checkout how you can clone.
 
 ---
@@ -136,7 +136,7 @@ _(Github is just another remote repository.)_
 ---
 
 > **_Demo_:**  
-> 1. Edit a file on Github.  
+> 1. Edit a file on GitHub.  
 2. Pull it's changes down.  
 
 ---
@@ -219,9 +219,9 @@ When you encounter a conflict, you need to edit the file by hand.
 
 ### Forks and Pull-Requests
 
-These are Github specific terms (though other platforms have adopted them).
+These are GitHub specific terms (though other platforms have adopted them).
 
-* A "fork" is clone of a repository to your Github account.
+* A "fork" is clone of a repository to your GitHub account.
 * A "pull-request" is a formal request to merge forked code back into the original repo.
 
 ---

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# Intro to Git &amp; Github :octocat:  
+# Intro to Git &amp; GitHub :octocat:  
 
 **Presented by [Girl Develop It, Cincinnati](http://gdicincy.com)**
 
@@ -6,7 +6,7 @@ Ever make changes that broke your code and forgot how your code worked before? W
 
 Git is a popular version control application that can track your code changes, as well as help you to be more methodical in your programming. Win win! This session will introduce the basics of version control, how to use git to keep track of your changes to a project, and using [GitHub](http://github.com) to collaborate with other developers.
 
-Want to try git for yourself? Github has a 15-minute tutorial you can go through on your own [here](https://try.github.io). 
+Want to try git for yourself? GitHub has a 15-minute tutorial you can go through on your own [here](https://try.github.io). 
 
 ## This workshop will cover…
 
@@ -27,7 +27,7 @@ We will be changing directories, listing directory contents, and using git from 
 Mac, [http://git-scm.com/download/mac](http://git-scm.com/download/mac)  
 Windows, [https://git-for-windows.github.io/](https://git-for-windows.github.io/)
 
-3. **A Github account…**  
+3. **A GitHub account…**  
 Sign up for free at [https://github.com/join](https://github.com/join).
 
 ## Course Materials

--- a/slides.md
+++ b/slides.md
@@ -115,7 +115,7 @@ Created by Linus Torvalds in 2005 for Linux Kernel Development
 1. Very fast and efficient <!-- .element: class="fragment" -->
 1. Cheap local branching <!-- .element: class="fragment" -->
 1. Works great remotely <!-- .element: class="fragment" -->
-1. Popularized by Github <!-- .element: class="fragment" -->
+1. Popularized by GitHub <!-- .element: class="fragment" -->
 
 ---
 
@@ -133,18 +133,18 @@ Created by Linus Torvalds in 2005 for Linux Kernel Development
 
 There are also some GUIs for Git...
 
-* [Github for Mac and Windows](https://desktop.github.com/)
+* [GitHub for Mac and Windows](https://desktop.github.com/)
 * [and many more...](https://git.wiki.kernel.org/index.php/InterfacesFrontendsAndTools#Graphical_Interfaces)
 
 ---
 
-## What is Github?
+## What is GitHub?
 
-Github helps you visualize your repository while providing some powerful collaboration and code management tools.
+GitHub helps you visualize your repository while providing some powerful collaboration and code management tools.
 
 * Forks &amp; Pull Requests <!-- .element: class="fragment" -->
 * Issues <!-- .element: class="fragment" -->
-* Wikis &amp; Github Pages<!-- .element: class="fragment" -->
+* Wikis &amp; GitHub Pages<!-- .element: class="fragment" -->
 * Organizations <!-- .element: class="fragment" -->
 * Releases &amp; Tags <!-- .element: class="fragment" -->
 * ...and more <!-- .element: class="fragment" -->
@@ -448,7 +448,7 @@ __`h`__ or __`←`__ - Move cursor left
 
 ---
 
-## Intro to Git and Github
+## Intro to Git and GitHub
 <img src="https://media.giphy.com/media/JIX9t2j0ZTN9S/giphy.gif">
 
 ---
@@ -596,18 +596,18 @@ Why would you use remote repos?
 <br><br>
 Each repository can have multiple "remotes", you refer to them with aliases.  
 <br><br>
-Github is just another remote repository.
+GitHub is just another remote repository.
 
 ---
 
 ##**_In-Class Exercise (5-minutes)_:** 
 
-Create a New Github Repo
+Create a New GitHub Repo
 
-1. Login to Github.
+1. Login to GitHub.
 2. Create a new public repository.
 3. Follow on-screen instructions to add remote to your local repository.
-4. Push changes to Github.
+4. Push changes to GitHub.
 5. Checkout how you can clone.
 
 ---
@@ -631,7 +631,7 @@ Create a New Github Repo
 ---
 
  **_Demo_:**  
-1. Edit a file on Github.  
+1. Edit a file on GitHub.  
 2. Pull it's changes down.  
 
 ---
@@ -720,9 +720,9 @@ When you encounter a conflict, you need to edit the file by hand.
 
 ### Forks and Pull-Requests
 
-These are Github specific terms (though other platforms have adopted them).
+These are GitHub specific terms (though other platforms have adopted them).
 
-* A "fork" is clone of a repository to your Github account.
+* A "fork" is clone of a repository to your GitHub account.
 * A "pull-request" is a formal request to merge forked code back into the original repo.
 
 ---
@@ -749,7 +749,7 @@ You did it!<br>
 * <a href="https://www.codecademy.com/learn/learn-git">Code Academy: Learn Git</a>
 * <a href="https://www.freecodecamp.org/challenges/save-your-code-revisions-forever-with-git">Free Code Camp: Git</a>
 * <a href="https://learngitbranching.js.org/">Git Branching Tutorial</a>
-* <a href="https://guides.github.com/introduction/flow/index.html">Github Flow</a>
+* <a href="https://guides.github.com/introduction/flow/index.html">GitHub Flow</a>
 * <a href="http://ndpsoftware.com/git-cheatsheet.html">Interactive Git Cheat Sheet</a>
 * <a href="https://github.com/github/training-kit/blob/master/downloads/github-git-cheat-sheet.pdf">Official Git Hub Git Cheat Sheet</a>
 * <a href="http://firstaidgit.io/#/">Saving guide for fixing common git fails</a>

--- a/slides.md
+++ b/slides.md
@@ -121,10 +121,10 @@ Created by Linus Torvalds in 2005 for Linux Kernel Development
 
 ## Getting Git
 
-* **OSX:**  
+* **macOS:**  
   Download [Git for Mac](http://git-scm.com/download/mac)
 
-* **Windows**  
+* **Windows:**  
   Download [Git for Windows](https://git-for-windows.github.io/)
 
 ---
@@ -167,7 +167,7 @@ A Unix "shell" is a command-line interpreter that provides a traditional user in
 <br><br>
 * There are a [bunch of different shells](http://www.ibm.com/developerworks/library/l-linux-shells/figure1.gif)... Bourne shell, C shell, Korn shell, Z shell, etc.
 * The first major shell was the Bourne Shell, developed in the late 70's.
-* We're going to focus on the "Bourne again shell" or _Bash_ (default shell for OSX and Linux)
+* We're going to focus on the "Bourne again shell" or _Bash_ (default shell for macOS and Linux)
 
 <br><br>
 
@@ -366,7 +366,7 @@ The directory or file(s) you want edit... `vim <path>`
 
 ## Editing Text Files with Vim
 
-Vim (which stands for Vi-improved) is a heavy-duty text-editor alot of developers use full-time.
+Vim (which stands for Vi-improved) is a heavy-duty text-editor a lot of developers use full-time.
 
 ![](src/images/vim.png)
 
@@ -461,8 +461,8 @@ __`h`__ or __`←`__ - Move cursor left
 
 First, let's personalize Git by setting some configuration values...
 
-<pre><code>`git config --global user.name "Your Name"`</code></pre>  
-<pre><code>`git config --global user.email "your_email@whatever.com"`</code></pre>
+<pre><code>git config --global user.name "Your Name"</code></pre>  
+<pre><code>git config --global user.email "your_email@whatever.com"</code></pre>
 
 ---
 
@@ -533,13 +533,13 @@ If you ever make a mistake, you can recover a previous state of a file.
 `git log`
 
 * See all the save-points over the lifetime of this repository.
-* It's your safety net– you can always get back to anything.
+* It's your safety net&mdash;you can always get back to anything.
 
 ---
 
  **_Demo_:**  
 1. Add new `README.md` and update `index.html`  
-2. Make two seperate commits to illustrate staging area.
+2. Make two separate commits to illustrate staging area.
 
 _(Checkout `git log -p`)_ <!-- .element: class="fragment" -->
 
@@ -592,11 +592,13 @@ Why would you use remote repos?
 * Backups
 * Deployment
 * Automated Services
+<br><br>
 
-<br><br>
-Each repository can have multiple "remotes", you refer to them with aliases.  
-<br><br>
-GitHub is just another remote repository.
+#### Each repository can have multiple "remotes"
+
+* You can refer to them with short names like `origin` or `myfork`.
+* The default name for a remote is `origin`.
+* GitHub is just another remote repository.
 
 ---
 
@@ -608,7 +610,8 @@ Create a New GitHub Repo
 2. Create a new public repository.
 3. Follow on-screen instructions to add remote to your local repository.
 4. Push changes to GitHub.
-5. Checkout how you can clone.
+5. Check out how you can clone.
+6. Look at your "remotes" with `git remote -v`.
 
 ---
 
@@ -621,22 +624,20 @@ Create a New GitHub Repo
 
 ---
 
-`git push <remote-alias> <branch-name>`
+`git push <remote-name> <branch-name>`
 
 * Push code on specific branch to a remote repository.
 * Copies your entire commit history to the remote.
-
-
 
 ---
 
  **_Demo_:**  
 1. Edit a file on GitHub.  
-2. Pull it's changes down.  
+2. Pull its changes down.  
 
 ---
 
-`git pull <remote-alias> <branch-name>`
+`git pull <remote-name> <branch-name>`
 
 * Copies updates from a remote repository to your computer.
 * Git will try to automatically merge your code.


### PR DESCRIPTION
* global search-and-replace "Github" with "GitHub"
* refer to Git remotes as simply "remote names" in a couple of slides since Git already has a (super-useful!) thing called "aliases"
* other minor typos corrected